### PR TITLE
Ip whitelisting & blocking

### DIFF
--- a/src/main/java/com/michielo/antivpn/AntiVPN.java
+++ b/src/main/java/com/michielo/antivpn/AntiVPN.java
@@ -1,5 +1,6 @@
 package com.michielo.antivpn;
 
+import com.michielo.antivpn.bukkit.command.AntiVpnCommandListener;
 import com.michielo.antivpn.bukkit.listener.PlayerJoinListener;
 import com.michielo.antivpn.manager.CacheManager;
 import com.michielo.antivpn.manager.ConfigManager;
@@ -17,6 +18,9 @@ public class AntiVPN extends JavaPlugin {
 
         // listener
         getServer().getPluginManager().registerEvents(new PlayerJoinListener(), this);
+
+        // commandhandler
+        this.getCommand("antivpn").setExecutor(new AntiVpnCommandListener());
     }
 
     @Override

--- a/src/main/java/com/michielo/antivpn/bukkit/command/AntiVpnCommandListener.java
+++ b/src/main/java/com/michielo/antivpn/bukkit/command/AntiVpnCommandListener.java
@@ -1,0 +1,76 @@
+package com.michielo.antivpn.bukkit.command;
+
+import com.michielo.antivpn.manager.CacheManager;
+import com.michielo.antivpn.util.IPUtil;
+import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+
+public class AntiVpnCommandListener implements CommandExecutor {
+
+    @Override
+    public boolean onCommand(CommandSender commandSender, Command c, String command, String[] args) {
+        //this case should already not happen but yk
+        if (!command.equalsIgnoreCase("antivpn")) return false;
+
+        // invalid arg length
+        if (args.length == 0 || args.length > 2) {
+            sendhelp(commandSender);
+            return true;
+        }
+
+        // IP whitelisting
+        if (args[0].equalsIgnoreCase("whitelist")) {
+            if (!commandSender.hasPermission("antivpn.whitelist") && !commandSender.isOp()) {
+                commandSender.sendMessage(ChatColor.RED + "You don't have permission to do this!");
+                return true;
+            }
+
+            if (args.length < 2) {
+                commandSender.sendMessage("Please use '/antivpn whitelist <IP>'");
+                return true;
+            }
+
+            String ip = args[1];
+            if (!IPUtil.isValidIPv4(ip)) {
+                commandSender.sendMessage("'" + ip + "' doesn't seem to be a valid IPV4 address!");
+                return true;
+            }
+            CacheManager.getInstance().getCache().storePermanent(ip, "true");
+            commandSender.sendMessage("'" + ip + "' has been whitelisted!");
+            return true;
+        }
+
+        // IP blocking
+        if (args[0].equalsIgnoreCase("block")) {
+            if (!commandSender.hasPermission("antivpn.block") && !commandSender.isOp()) {
+                commandSender.sendMessage(ChatColor.RED + "You don't have permission to do this!");
+                return true;
+            }
+
+            if (args.length < 2) {
+                commandSender.sendMessage("Please use '/antivpn block <IP>'");
+                return true;
+            }
+
+            String ip = args[1];
+            if (!IPUtil.isValidIPv4(ip)) {
+                commandSender.sendMessage("'" + ip + "' doesn't seem to be a valid IPV4 address!");
+                return true;
+            }
+            CacheManager.getInstance().getCache().storePermanent(ip, "false");
+            commandSender.sendMessage("'" + ip + "' has been blocked!");
+            return true;
+        }
+
+        sendhelp(commandSender);
+        return false;
+    }
+
+    private void sendhelp(CommandSender commandSender) {
+        commandSender.sendMessage("'/antivpn whitelist <IP>' whitelists an IP");
+        commandSender.sendMessage("'/antivpn block <IP>' blocks an IP");
+    }
+
+}

--- a/src/main/java/com/michielo/antivpn/cache/AbstractCache.java
+++ b/src/main/java/com/michielo/antivpn/cache/AbstractCache.java
@@ -19,12 +19,16 @@ public abstract class AbstractCache {
     }
 
     public abstract void store(String key, String value, long expirationTime);
+    public abstract void storePermanent(String key, String value);
     public abstract String retrieve(String key);
+    public abstract String retrievePermanent(String key);
     public abstract void invalidate(String key);
 
     public void clear() {
         cache.clear();
     }
+    public abstract void removePermanent(String key);
+    public abstract void clearPermanentStorage();
 
     public int size() {
         return cache.size();

--- a/src/main/java/com/michielo/antivpn/manager/ApiManager.java
+++ b/src/main/java/com/michielo/antivpn/manager/ApiManager.java
@@ -40,16 +40,29 @@ public class ApiManager {
 
     public VPNResult isAVPN(String ip) {
 
+        // check for local IP
         if (isLocal(ip)) {
             return VPNResult.NEGATIVE;
         }
 
+        // check for hard blocked/whitelisted
+        String hardfixed = CacheManager.getInstance().getCache().retrievePermanent(ip);
+        if (hardfixed != null)  {
+            if (hardfixed.equalsIgnoreCase("true")) {
+                return VPNResult.NEGATIVE;
+            } else {
+                return VPNResult.POSITIVE;
+            }
+        }
+
+        // check for cached result
         String cachedResult = CacheManager.getInstance().getCache().retrieve(ip);
         if (cachedResult != null) {
             Bukkit.getLogger().info("[AntiVPN] Used a cached result!");
             return VPNResult.valueOf(cachedResult);
         }
 
+        // get new result
         VpnAPI primaryAPI = apis.get(primary);
         VPNResult primaryResult = primaryAPI.checkIP(ip);
         if (primaryResult != VPNResult.UNKNOWN) {

--- a/src/main/java/com/michielo/antivpn/util/IPUtil.java
+++ b/src/main/java/com/michielo/antivpn/util/IPUtil.java
@@ -1,0 +1,19 @@
+package com.michielo.antivpn.util;
+
+import java.util.regex.Pattern;
+
+public class IPUtil {
+    private static final Pattern IPV4_PATTERN = Pattern.compile(
+            "^(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\." +
+                    "(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\." +
+                    "(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\." +
+                    "(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$"
+    );
+
+    public static boolean isValidIPv4(String ip) {
+        if (ip == null || ip.isEmpty()) {
+            return false;
+        }
+        return IPV4_PATTERN.matcher(ip).matches();
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -4,3 +4,4 @@ author: Michielo
 main: com.michielo.antivpn.AntiVPN
 
 commands:
+  antivpn:


### PR DESCRIPTION
**Changes**

- Added IPUtils to check string for IPV4
- Updated AbstractCache (+ cache implementations) to include more permanent storage
- Added commands to whitelist and block IP's (which get stored in the more permanent storage)
- Added checking for whitelisted or blocked IP's in ApiManager

added unused methods for clearing permanent storage which can later be hooked up to a clear command to nicely clean everything up completely.