### PR TITLE
Initial location collection

### DIFF
--- a/src/main/java/com/michielo/antivpn/api/impl/KauriAPI.java
+++ b/src/main/java/com/michielo/antivpn/api/impl/KauriAPI.java
@@ -5,6 +5,7 @@ import com.google.gson.JsonParser;
 import com.michielo.antivpn.api.APIResult;
 import com.michielo.antivpn.api.VPNResult;
 import com.michielo.antivpn.api.VpnAPI;
+import org.bukkit.Bukkit;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -49,12 +50,13 @@ public class KauriAPI implements VpnAPI {
             http.disconnect();
 
             Boolean proxy = Boolean.valueOf(jsonObject.get("proxy").getAsString());
+            String location = jsonObject.get("latitude").getAsString() + ";" + jsonObject.get("longitude").getAsString();
 
             VPNResult result = VPNResult.NEGATIVE;
             if (proxy) result = VPNResult.POSITIVE;
 
-            return new APIResult(result);
-        } catch (IOException e) {
+            return new APIResult(result, location);
+        } catch (IOException | NullPointerException e) {
             e.printStackTrace();
         }
         return new APIResult(VPNResult.UNKNOWN);


### PR DESCRIPTION
Looking to see if this is stable in production, will not affect any current functionality. Currently only applies to the KauriVPN API.


This PR introduces no new functionality. This starts collecting location data to see if this works in a stable manner without impeding other functionality. Upcoming releases will focus on detecting abusive connections in the form of multiple connections over multiple IP addresses from the same location, location collection is vital in this which is why I want to have this experimental collection in a release without impeding anything to see if it's stable.